### PR TITLE
Fix: Once a new session is created, wait for the browser to become in…

### DIFF
--- a/java/server/src/com/appdynamics/wpt/WptHookClient.java
+++ b/java/server/src/com/appdynamics/wpt/WptHookClient.java
@@ -40,7 +40,9 @@ public class WptHookClient {
 
   public void notifyNextWebdriverAction() {
     try {
+      log.info("Sending /event/webdriver_done command to the hook");
       getResponse(nextActionUrl);
+      log.info("Done sending /event/webdriver_done command to the hook");
     } catch (Exception e) {
       // ignore.
     }
@@ -49,7 +51,9 @@ public class WptHookClient {
   public boolean isHookReady() {
     String response;
     try {
+      log.info("Sending /is_hook_ready query to the hook");
       response = getResponse(hookReadyUrl);
+      log.info("Done sending /is_hook_ready query to the hook");
     } catch(IOException e) {
       this.log.info("Can't connect to hook, probably not ready");
       return false;
@@ -61,11 +65,15 @@ public class WptHookClient {
   }
 
   public void notifyWebdriverDone() throws IOException {
+    log.info("Sending /event/webdriver_done command to the hook");
     getResponse(webdriverDoneUrl);
+    log.info("Done sending /event/webdriver_done command to the hook");
   }
 
-  public static String getResponse(URL url) throws IOException {
+  public String getResponse(URL url) throws IOException {
+    log.info("\t Before openConnection");
     HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    log.info("\t After openConnection");
     return CharStreams.toString(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
   }
 

--- a/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
+++ b/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
@@ -31,6 +31,7 @@ import org.openqa.selenium.remote.server.DriverSessions;
 import org.openqa.selenium.remote.server.JsonParametersAware;
 import org.openqa.selenium.remote.server.Session;
 import org.openqa.selenium.remote.server.handler.DeleteSession;
+import org.openqa.selenium.remote.server.handler.NewSession;
 import org.openqa.selenium.remote.server.handler.WebDriverHandler;
 import org.openqa.selenium.remote.server.log.LoggingManager;
 import org.openqa.selenium.remote.server.log.PerSessionLogHandler;
@@ -221,6 +222,15 @@ public class ResultConfig {
         log.fine("Done: " + handler);
       } else {
         log.info("Done: " + handler);
+      }
+
+      if (NEW_SESSION.equals(command.getName())) {
+        NewSession newSessionHandler = (NewSession) handler;
+        if (newSessionHandler.getCapabilities().is(WPT_LOCK_STEP)) {
+          // We just created the browser. Wait until the hook tells us that the browser is ready
+          // to interact.
+          wptHookClient.waitUntilHookReady();
+        }
       }
     } catch (UnreachableBrowserException e) {
       throwUpIfSessionTerminated(sessionId);


### PR DESCRIPTION
…teractive
- on a new session command, the browser starts up, but the hook can take a while
  to deem the browser ready (hook waits for about 30 seconds for the CPU usage
  to go below 20%). Wait for this event to happen before returning back to the
  webdriver client.
- add more details in the logs to aid in debugging.
