### PR TITLE
Add an option to log all screenshots server side

### DIFF
--- a/java/server/src/org/openqa/selenium/remote/server/handler/CaptureScreenshot.java
+++ b/java/server/src/org/openqa/selenium/remote/server/handler/CaptureScreenshot.java
@@ -17,27 +17,60 @@
 
 package org.openqa.selenium.remote.server.handler;
 
-import static org.openqa.selenium.OutputType.BASE64;
+import static org.openqa.selenium.OutputType.BYTES;
+
+import com.google.common.io.Files;
 
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.internal.Base64Encoder;
 import org.openqa.selenium.remote.server.Session;
+
+import java.io.File;
+import java.io.IOException;
 
 public class CaptureScreenshot extends WebDriverHandler<String> {
 
+  private File dumpDir;
+
   public CaptureScreenshot(Session session) {
     super(session);
+
+    String path = System.getProperty("webdriver.saveScreenshots");
+    if (path != null && !path.isEmpty()) {
+      dumpDir = new File(path);
+      dumpDir.mkdirs();
+    }
   }
 
   @Override
   public String call() throws Exception {
     WebDriver driver = getUnwrappedDriver();
 
-    return ((TakesScreenshot) driver).getScreenshotAs(BASE64);
+    byte[] png = ((TakesScreenshot) driver).getScreenshotAs(BYTES);
+
+    if (dumpDir != null) {
+      save(dumpDir, png);
+    }
+    return new Base64Encoder().encode(png);
   }
 
   @Override
   public String toString() {
     return "[take screenshot]";
+  }
+
+  private File save(File folder, byte[] data) {
+    try {
+      String filename = System.currentTimeMillis() + "_screenshot.png";
+
+      File file = new File(folder, filename);
+      Files.write(data, file);
+
+      return file;
+    } catch (IOException e) {
+      throw new WebDriverException(e);
+    }
   }
 }


### PR DESCRIPTION
This PR adds the option to dump all taken images on disk to a specified
folder by using -D"webdriver.saveScreenshots"=<PATH TO DIR>
