### PR TITLE
CORE-90785 Add an endpoint to retrieve the remote webdriver URL

### DIFF
--- a/java/client/src/org/openqa/selenium/remote/DriverCommand.java
+++ b/java/client/src/org/openqa/selenium/remote/DriverCommand.java
@@ -175,4 +175,7 @@ public interface DriverCommand {
   // Mobile API
   String GET_NETWORK_CONNECTION = "getNetworkConnection";
   String SET_NETWORK_CONNECTION = "setNetworkConnection";
+
+  // Used to access the remote driver directly
+  String GET_REMOTE_DRIVER_URL = "getRemoteDriverUrl";
 }

--- a/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
+++ b/java/client/src/org/openqa/selenium/remote/RemoteWebDriver.java
@@ -1029,6 +1029,10 @@ public class RemoteWebDriver implements WebDriver, JavascriptExecutor,
     }
   }
 
+  public CommandExecutor getExecutor() {
+    return executor;
+  }
+
   public enum When {
     BEFORE,
     AFTER,

--- a/java/client/src/org/openqa/selenium/remote/http/AbstractHttpCommandCodec.java
+++ b/java/client/src/org/openqa/selenium/remote/http/AbstractHttpCommandCodec.java
@@ -105,6 +105,7 @@ import static org.openqa.selenium.remote.DriverCommand.TOUCH_SCROLL;
 import static org.openqa.selenium.remote.DriverCommand.TOUCH_SINGLE_TAP;
 import static org.openqa.selenium.remote.DriverCommand.TOUCH_UP;
 import static org.openqa.selenium.remote.DriverCommand.UPLOAD_FILE;
+import static org.openqa.selenium.remote.DriverCommand.GET_REMOTE_DRIVER_URL;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
@@ -242,6 +243,9 @@ public abstract class AbstractHttpCommandCodec implements CommandCodec<HttpReque
     defineCommand(SWITCH_TO_CONTEXT, post("/session/:sessionId/context"));
     defineCommand(GET_CURRENT_CONTEXT_HANDLE, get("/session/:sessionId/context"));
     defineCommand(GET_CONTEXT_HANDLES, get("/session/:sessionId/contexts"));
+
+    // Remote driver direct access
+    defineCommand(GET_REMOTE_DRIVER_URL, get("/session/:sessionId/remote_driver_url"));
   }
 
   @Override

--- a/java/server/src/org/openqa/selenium/remote/server/JsonHttpCommandHandler.java
+++ b/java/server/src/org/openqa/selenium/remote/server/JsonHttpCommandHandler.java
@@ -74,6 +74,7 @@ import org.openqa.selenium.remote.server.handler.GetElementSize;
 import org.openqa.selenium.remote.server.handler.GetElementText;
 import org.openqa.selenium.remote.server.handler.GetLogHandler;
 import org.openqa.selenium.remote.server.handler.GetPageSource;
+import org.openqa.selenium.remote.server.handler.GetRemoteDriverUrl;
 import org.openqa.selenium.remote.server.handler.GetScreenOrientation;
 import org.openqa.selenium.remote.server.handler.GetSessionCapabilities;
 import org.openqa.selenium.remote.server.handler.GetSessionLogsHandler;
@@ -369,5 +370,7 @@ public class JsonHttpCommandHandler {
     addNewMapping("getWindowSize", GetWindowSize.class);
     addNewMapping("setWindowSize", SetWindowSize.class);
     addNewMapping("maximizeWindow", MaximizeWindow.class);
+
+    addNewMapping(GET_REMOTE_DRIVER_URL, GetRemoteDriverUrl.class);
   }
 }

--- a/java/server/src/org/openqa/selenium/remote/server/handler/GetRemoteDriverUrl.java
+++ b/java/server/src/org/openqa/selenium/remote/server/handler/GetRemoteDriverUrl.java
@@ -1,0 +1,52 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.remote.server.handler;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.HttpCommandExecutor;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.server.Session;
+import org.openqa.selenium.support.events.EventFiringWebDriver;
+
+public class GetRemoteDriverUrl extends WebDriverHandler<String> {
+
+
+  public GetRemoteDriverUrl(Session session) {
+    super(session);
+  }
+
+  @Override
+  public String call() throws Exception {
+    WebDriver wd = getDriver();
+    if (wd instanceof EventFiringWebDriver)
+      wd = ((EventFiringWebDriver)wd).getWrappedDriver();
+    if (wd instanceof RemoteWebDriver) {
+      RemoteWebDriver rwd = (RemoteWebDriver) wd;
+      if (rwd.getExecutor() instanceof HttpCommandExecutor) {
+        HttpCommandExecutor httpCommandExecutor = (HttpCommandExecutor) rwd.getExecutor();
+        return httpCommandExecutor.getAddressOfRemoteServer() + "/session/" + rwd.getSessionId();
+      }
+    }
+    return "";
+  }
+
+  @Override
+  public String toString() {
+    return "[get remote driver url]";
+  }
+}


### PR DESCRIPTION
This is needed for edge cases when directly accessing the remote driver
is more efficient than going through the selenium server. An example of
such cases is when requesting to download very large performance logs.