### PR TITLE
SYNTH-1310 : Added a new flag to flush all sessions

### DIFF
--- a/java/client/src/org/openqa/selenium/AppdynamicsCapability.java
+++ b/java/client/src/org/openqa/selenium/AppdynamicsCapability.java
@@ -30,9 +30,16 @@ public class AppdynamicsCapability {
    */
   public static String TEST_ID = "testId";
 
+  /**
+   * This capability ensures that a new session is returned rather than the Singleton session
+   * Should be "true" or "false"
+   */
+  public static String FLUSH_SESSIONS = "flushSessions";
+
   private String outputDir;
   private String testID;
   private String commandWebhook;
+  private boolean flushSessions;
   /**
    * AppDynamics extension
    *
@@ -50,6 +57,9 @@ public class AppdynamicsCapability {
     if (map.containsKey(COMMAND_WEBHOOK) && !Strings.isNullOrEmpty(map.get(COMMAND_WEBHOOK))) {
       this.commandWebhook = map.get(COMMAND_WEBHOOK);
     }
+    if (map.containsKey(FLUSH_SESSIONS) && !Strings.isNullOrEmpty(map.get(FLUSH_SESSIONS))) {
+      this.flushSessions = Boolean.parseBoolean(map.get(FLUSH_SESSIONS));
+    }
   }
 
   public AppdynamicsCapability() {
@@ -66,6 +76,10 @@ public class AppdynamicsCapability {
 
   public String getCommandWebhook() {
     return this.commandWebhook;
+  }
+
+  public boolean flushSessions() {
+    return this.flushSessions;
   }
 
   public ImmutableMap<String, String> getEnvironment() {

--- a/java/server/src/org/openqa/selenium/remote/server/SingletonDriverSessions.java
+++ b/java/server/src/org/openqa/selenium/remote/server/SingletonDriverSessions.java
@@ -1,25 +1,40 @@
 package org.openqa.selenium.remote.server;
 
+import org.openqa.selenium.AppdynamicsCapability;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.remote.SessionId;
+
+import java.util.logging.Logger;
 
 /**
  * Created by olivier.crameri on 2/26/16.
  */
 public class SingletonDriverSessions extends DefaultDriverSessions {
-
+    private static final Logger logger = Logger.getLogger(SingletonDriverSessions.class.getName());
     private volatile SessionId uniqueSessionId = null;
 
     public SessionId newSession(Capabilities desiredCapabilities) throws Exception {
         synchronized (this) {
-            if (uniqueSessionId == null)
-                uniqueSessionId = super.newSession(desiredCapabilities);
+            AppdynamicsCapability appdynamicsCapability = AppdynamicsCapability.extractFrom(desiredCapabilities);
+            if (uniqueSessionId == null || appdynamicsCapability.flushSessions()) {
+              flushAllExistingSessions();
+              logger.info("NewSession: Creating new Session");
+              uniqueSessionId = super.newSession(desiredCapabilities);
+            }
         }
         return uniqueSessionId;
     }
+
     public void deleteSession(SessionId sessionId) {
         if (uniqueSessionId != null && uniqueSessionId.equals(sessionId))
             uniqueSessionId = null;
         super.deleteSession(sessionId);
+    }
+
+    private void flushAllExistingSessions() {
+      logger.info("NewSession: Flushing all sessions");
+      for (SessionId sessionId : super.getSessions()) {
+        super.deleteSession(sessionId);
+      }
     }
 }


### PR DESCRIPTION
The new flag will allow us to explicitly flush all sessions
and then create a new one. This will avoid the problem of reference
counting and possibly having an extra session lying around.
    
Testing notes -
- Created and used with the synth agent. Made sure measurements ran correctly
and the logs showed that the sessions were flushed and a new session
was created.
