### PR TITLE
SYNTH-1714 : The selenium server wasnt flushing the sessions correctly

### DIFF
--- a/java/server/src/org/openqa/selenium/remote/server/SingletonDriverSessions.java
+++ b/java/server/src/org/openqa/selenium/remote/server/SingletonDriverSessions.java
@@ -2,7 +2,10 @@ package org.openqa.selenium.remote.server;
 
 import org.openqa.selenium.AppdynamicsCapability;
 import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.remote.Command;
 import org.openqa.selenium.remote.SessionId;
+import org.openqa.selenium.remote.server.handler.DeleteSession;
+import org.openqa.selenium.remote.server.rest.RestishHandler;
 
 import java.util.logging.Logger;
 
@@ -22,6 +25,7 @@ public class SingletonDriverSessions extends DefaultDriverSessions {
               uniqueSessionId = super.newSession(desiredCapabilities);
             }
         }
+        logger.info("Session ID is " + uniqueSessionId.toString());
         return uniqueSessionId;
     }
 
@@ -34,6 +38,12 @@ public class SingletonDriverSessions extends DefaultDriverSessions {
     private void flushAllExistingSessions() {
       logger.info("NewSession: Flushing all sessions");
       for (SessionId sessionId : super.getSessions()) {
+        DeleteSession deleteSession = new DeleteSession(super.get(sessionId));
+        try {
+            deleteSession.call();
+        } catch (Exception e) {
+            logger.info("Quiting the session failed due to " + e.toString());
+        }
         super.deleteSession(sessionId);
       }
     }


### PR DESCRIPTION
The server was previously just removing it from the server's internal
data structure keeping track of the active sessions. We were removing
session from here but we werent calling QUIT on the actual driver
server. Changed the code to do this now.

Testing notes -
- Ran a sample script which created 3 drivers. The first two had
flushSessions set as True. Made sure that the first browser
and chromedriver intance was deleted when the second ones were
created.