### PR TITLE
SYNTH-3329 Remove info about credentials from webdriver logs

### DIFF
--- a/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
+++ b/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
@@ -40,6 +40,7 @@ import org.openqa.selenium.remote.server.handler.DeleteSession;
 import org.openqa.selenium.remote.server.handler.WebDriverHandler;
 import org.openqa.selenium.remote.server.log.LoggingManager;
 import org.openqa.selenium.remote.server.log.PerSessionLogHandler;
+import java.util.regex.Pattern;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -58,12 +59,10 @@ public class ResultConfig {
   private final Logger log;
   // lazy initialization by the first call of ResultConfig. This is needed to propagate the log object
   private static CommandWebhookClient commandWebhookClient;
-  private static final java.util.regex.Pattern sendKeysPattern =
-    java.util.regex.Pattern
-      .compile("(.*)(send keys:).*(])", java.util.regex.Pattern.CASE_INSENSITIVE);
-  private static final java.util.regex.Pattern credentialsPattern =
-    java.util.regex.Pattern
-      .compile("(.*)(https?://).*@(.*$)", java.util.regex.Pattern.CASE_INSENSITIVE);
+  private static final Pattern sendKeysPattern =
+    Pattern.compile("(.*)(send keys:).*(])", java.util.regex.Pattern.CASE_INSENSITIVE);
+  private static final Pattern credentialsPattern =
+    Pattern.compile("(.*)(https?://).*@(.*$)", java.util.regex.Pattern.CASE_INSENSITIVE);
 
   public ResultConfig(
       String commandName, Class<? extends RestishHandler<?>> handlerClazz,

--- a/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
+++ b/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
@@ -18,6 +18,7 @@
 package org.openqa.selenium.remote.server.rest;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
 import com.appdynamics.webhook.CommandWebhookClient;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 
 public class ResultConfig {
 
@@ -113,9 +115,9 @@ public class ResultConfig {
       throwUpIfSessionTerminated(sessionId);
 
       if (DriverCommand.STATUS.equals(command.getName())) {
-        log.fine(String.format("Executing: %s)", handler));
+        log.fine(removeCredentials("Executing: " + handler));
       } else {
-        log.info(String.format("Executing: %s)", handler));
+        log.info(removeCredentials("Executing: " + handler));
       }
 
       reportCommand(sessionId, command);
@@ -131,9 +133,9 @@ public class ResultConfig {
       }
 
       if (DriverCommand.STATUS.equals(command.getName())) {
-        log.fine("Done: " + handler);
+        log.fine(removeCredentials("Done: " + handler));
       } else {
-        log.info("Done: " + handler);
+        log.info(removeCredentials("Done: " + handler));
       }
 
     } catch (UnreachableBrowserException e) {
@@ -164,6 +166,34 @@ public class ResultConfig {
       sessions.deleteSession(sessionId);
     }
     return response;
+  }
+
+  private String removeCredentials(String command) {
+    if (Strings.isNullOrEmpty(command)) {
+      return command;
+    }
+
+    if (command.contains("send keys")) {
+      java.util.regex.Pattern credentialsPattern =
+        java.util.regex.Pattern
+          .compile("(.*)(send keys:).*(])", java.util.regex.Pattern.CASE_INSENSITIVE);
+      Matcher matcher = credentialsPattern.matcher(command);
+
+      if (matcher.matches()) {
+        return matcher.group(1) + matcher.group(2) + " REDACTED" + matcher.group(3);
+      }
+    } else {
+
+      java.util.regex.Pattern credentialsPattern =
+        java.util.regex.Pattern
+          .compile("(.*)(https?://).*@(.*$)(.*)", java.util.regex.Pattern.CASE_INSENSITIVE);
+      Matcher matcher = credentialsPattern.matcher(command);
+
+      if (matcher.matches()) {
+        return matcher.group(1) + matcher.group(2) + matcher.group(3) + matcher.group(4);
+      }
+    }
+    return command;
   }
 
   private void reportCommand(SessionId sessionId, Command command)

--- a/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
+++ b/java/server/src/org/openqa/selenium/remote/server/rest/ResultConfig.java
@@ -58,6 +58,12 @@ public class ResultConfig {
   private final Logger log;
   // lazy initialization by the first call of ResultConfig. This is needed to propagate the log object
   private static CommandWebhookClient commandWebhookClient;
+  private static final java.util.regex.Pattern sendKeysPattern =
+    java.util.regex.Pattern
+      .compile("(.*)(send keys:).*(])", java.util.regex.Pattern.CASE_INSENSITIVE);
+  private static final java.util.regex.Pattern credentialsPattern =
+    java.util.regex.Pattern
+      .compile("(.*)(https?://).*@(.*$)", java.util.regex.Pattern.CASE_INSENSITIVE);
 
   public ResultConfig(
       String commandName, Class<? extends RestishHandler<?>> handlerClazz,
@@ -174,23 +180,16 @@ public class ResultConfig {
     }
 
     if (command.contains("send keys")) {
-      java.util.regex.Pattern credentialsPattern =
-        java.util.regex.Pattern
-          .compile("(.*)(send keys:).*(])", java.util.regex.Pattern.CASE_INSENSITIVE);
-      Matcher matcher = credentialsPattern.matcher(command);
+      Matcher matcher = sendKeysPattern.matcher(command);
 
       if (matcher.matches()) {
         return matcher.group(1) + matcher.group(2) + " REDACTED" + matcher.group(3);
       }
     } else {
-
-      java.util.regex.Pattern credentialsPattern =
-        java.util.regex.Pattern
-          .compile("(.*)(https?://).*@(.*$)(.*)", java.util.regex.Pattern.CASE_INSENSITIVE);
       Matcher matcher = credentialsPattern.matcher(command);
 
       if (matcher.matches()) {
-        return matcher.group(1) + matcher.group(2) + matcher.group(3) + matcher.group(4);
+        return matcher.group(1) + matcher.group(2) + matcher.group(3);
       }
     }
     return command;


### PR DESCRIPTION
The selenium server logs all commands sent to the wendrivers. These
include the get commands which have the url being fetched and the
send keys command which might contain credentials. This creates a
possible security issue.

This patch will add logic which redacts whatever is being sent as
part of the send_keys command as well as remove any basic auth
credentials which might appear in the url when executing a get command.

Testing notes -
- tested manually by running a URL and a scripted job and then
manually making sure that the webdriver-server.log does not contain
any information in the get log and the send key logs are REDACTED