### PR TITLE
Fix "Unknown wait type" errors in the WebDriver server logs

### DIFF
--- a/java/server/src/org/openqa/selenium/remote/server/handler/ConfigureTimeout.java
+++ b/java/server/src/org/openqa/selenium/remote/server/handler/ConfigureTimeout.java
@@ -31,9 +31,11 @@ import java.util.stream.Collectors;
 public class ConfigureTimeout extends WebDriverHandler<Void> implements JsonParametersAware {
 
   private static final String IMPLICIT = "implicit";
-  private static final String PAGE_LOAD = "page load";
+  private static final String PAGE_LOAD_OSS = "page load";
+  private static final String PAGE_LOAD_W3C = "pageLoad";
   private static final String SCRIPT = "script";
-  private static final List<String> knownTypes = Arrays.asList(IMPLICIT, PAGE_LOAD, SCRIPT);
+  private static final List<String> knownTypes =
+      Arrays.asList(IMPLICIT, PAGE_LOAD_OSS, PAGE_LOAD_W3C, SCRIPT);
 
   private Map<String, Object> timeouts = new HashMap<>();
 
@@ -73,13 +75,22 @@ public class ConfigureTimeout extends WebDriverHandler<Void> implements JsonPara
             "Illegal (non-numeric) timeout value passed: " + timeouts.get(IMPLICIT), ex);
       }
     }
-    if (timeouts.containsKey(PAGE_LOAD)) {
+    if (timeouts.containsKey(PAGE_LOAD_OSS)) {
       try {
         getDriver().manage().timeouts().pageLoadTimeout(
-            ((Number) timeouts.get(PAGE_LOAD)).longValue(), TimeUnit.MILLISECONDS);
+            ((Number) timeouts.get(PAGE_LOAD_OSS)).longValue(), TimeUnit.MILLISECONDS);
       } catch (ClassCastException ex) {
         throw new WebDriverException(
-            "Illegal (non-numeric) timeout value passed: " + timeouts.get(PAGE_LOAD), ex);
+            "Illegal (non-numeric) timeout value passed: " + timeouts.get(PAGE_LOAD_OSS), ex);
+      }
+    }
+    if (timeouts.containsKey(PAGE_LOAD_W3C)) {
+      try {
+        getDriver().manage().timeouts().pageLoadTimeout(
+            ((Number) timeouts.get(PAGE_LOAD_W3C)).longValue(), TimeUnit.MILLISECONDS);
+      } catch (ClassCastException ex) {
+        throw new WebDriverException(
+            "Illegal (non-numeric) timeout value passed: " + timeouts.get(PAGE_LOAD_OSS), ex);
       }
     }
     if (timeouts.containsKey(SCRIPT)) {


### PR DESCRIPTION
Somewhere between selenium versions 3.0.1 and 3.8.1, upstream code
committers have introduced a bug that results in the following sequence:

1. WebDriver client invokes driver.set_page_load_timeout() [see
webdrivermanager.py]
2. remote/webdriver.py in selenium python module sends a HTTP request to
the server for the SET_TIMEOUTS command with the JSON payload consisting
of the 'pageLoad' key and the specified timeout (in milliseconds) as the
value.
3. The server receives this and tries to identify whether the command was
issued with the OSS dialect. Since that is not true, the server tries to
interpret the command using W3C dialect.
4. At this point, the server is unable to resolve the payload because the
key is 'pageLoad', but the server knows only about the old OSS type
'page load'.
5. As a result of this, a WebDriverException is issued.
6. The client handles this by falling back to OSS mode. This time it sets
the payload correctly, and the server is able to decode this.

The result of the above sequence of operations is that we see false
exceptions and stack traces in the WebDriver server log because of the
Step 5 above.

Selenium code has changed a lot since 3.8.1 in completely new ways that
we are not yet equipped to handle. So, we have to stick with 3.8.1 but
fix the code so that we don't report false exceptions and stack traces.

We do this by including the W3C 'pageLoad' attribute to the list of
known types and parse the payload.

Testing notes:
- Ran @sanity on Chrome and Firefox.
- Verified that as part of the above run, no unnecessary exceptions are
observed in the WebDriver server logs.