### PR TITLE
SYNTH-3725 SYNTH-4005 SYNTH-4006 Added code to capture driver logs from Chrome and IE10, and console logs and extension logs for Chrome

### DIFF
--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -135,7 +135,7 @@ public class ChromeDriver extends RemoteWebDriver
    * @see #ChromeDriver(ChromeDriverService, Capabilities)
    */
   public ChromeDriver(Capabilities capabilities) {
-    this(ChromeDriverService.createDefaultService(), capabilities);
+    this(ChromeDriverService.createDefaultServiceWithCustomOptions(capabilities), capabilities);
   }
 
   /**

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -108,7 +108,7 @@ public class ChromeDriverService extends DriverService {
 
   /**
    * Configures and returns a new {@link ChromeDriverService}. On top of the default configuration,
-   * this makes two additional changes -
+   * this makes two additional changes if the "captureLogs" option is set.
    * (1) This sets a default log file for the chromedriver using the options provided.
    * (2) This specifies an environment variable CHROME_LOG_FILE which is set before the browser is started.
    * In this configuration, the service will use the chromedriver executable identified by the
@@ -120,6 +120,11 @@ public class ChromeDriverService extends DriverService {
   public static ChromeDriverService createDefaultServiceWithCustomOptions(Capabilities capabilities) {
     Object appdynamicsCapabilities = capabilities.getCapability("appdynamicsCapability");
     Map<String, String> caps = (HashMap<String, String>) appdynamicsCapabilities;
+    if (!caps.containsKey("captureLogs") ||
+        caps.get("captureLogs") == null ||
+        caps.get("captureLogs").toLowerCase() != "true") {
+      return new Builder().usingAnyFreePort().build();
+    }
     String logFilePath = caps.get("outputDir") + File.separator + CHROME_DRIVER_LOG_FILE;
     File logFile = new File(logFilePath);
     Map<String, String> chromeEnvironment = new HashMap<>();

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -20,11 +20,14 @@ package org.openqa.selenium.chrome;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.remote.service.DriverService;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Manages the life and death of a chromedriver server.
@@ -64,6 +67,11 @@ public class ChromeDriverService extends DriverService {
   public final static String CHROME_DRIVER_WHITELISTED_IPS_PROPERTY = "webdriver.chrome.whitelistedIps";
 
   /**
+   * File that will be used by the ChromeDriverService to dump driver logs.
+   */
+  public final static String CHROME_DRIVER_LOG_FILE = "chromedriver.log";
+
+  /**
    *
    * @param executable The chromedriver executable.
    * @param port Which port to start the chromedriver on.
@@ -86,6 +94,24 @@ public class ChromeDriverService extends DriverService {
    */
   public static ChromeDriverService createDefaultService() {
     return new Builder().usingAnyFreePort().build();
+  }
+
+  /**
+   * Configures and returns a new {@link ChromeDriverService} using the default configuration and
+   * custom options. When ChromeDriverService is created, it identifies an immutable argument list
+   * at startup. The default list of arguments can be extended using the capabilities provided here.
+   * In this configuration, the service will use the chromedriver executable identified by the
+   * {@link #CHROME_DRIVER_EXE_PROPERTY} system property. Each service created by this method will
+   * be configured to use a free port on the current system.
+   *
+   * @return A new ChromeDriverService using the default configuration and custom options.
+   */
+  public static ChromeDriverService createDefaultServiceWithCustomOptions(Capabilities capabilities) {
+    Object appdynamicsCapabilities = capabilities.getCapability("appdynamicsCapability");
+    Map<String, String> caps = (HashMap<String, String>) appdynamicsCapabilities;
+    String logFilePath = caps.get("outputDir") + File.separator + CHROME_DRIVER_LOG_FILE;
+    File logFile = new File(logFilePath);
+    return new Builder().usingAnyFreePort().withLogFile(logFile).build();
   }
 
   /**

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -107,9 +107,10 @@ public class ChromeDriverService extends DriverService {
   }
 
   /**
-   * Configures and returns a new {@link ChromeDriverService} using the default configuration and
-   * custom options. When ChromeDriverService is created, it identifies an immutable argument list
-   * at startup. The default list of arguments can be extended using the capabilities provided here.
+   * Configures and returns a new {@link ChromeDriverService}. On top of the default configuration,
+   * this makes two additional changes -
+   * (1) This sets a default log file for the chromedriver using the options provided.
+   * (2) This specifies an environment variable CHROME_LOG_FILE which is set before the browser is started.
    * In this configuration, the service will use the chromedriver executable identified by the
    * {@link #CHROME_DRIVER_EXE_PROPERTY} system property. Each service created by this method will
    * be configured to use a free port on the current system.
@@ -121,9 +122,9 @@ public class ChromeDriverService extends DriverService {
     Map<String, String> caps = (HashMap<String, String>) appdynamicsCapabilities;
     String logFilePath = caps.get("outputDir") + File.separator + CHROME_DRIVER_LOG_FILE;
     File logFile = new File(logFilePath);
-    Map<String, String> chromeEnvironments = new HashMap<>();
-    chromeEnvironments.put(CHROME_LOG_FILE, caps.get("outputDir") + File.separator + CHROME_BROWSER_LOG_FILE);
-    return new Builder().usingAnyFreePort().withLogFile(logFile).withEnvironment(chromeEnvironments).build();
+    Map<String, String> chromeEnvironment = new HashMap<>();
+    chromeEnvironment.put(CHROME_LOG_FILE, caps.get("outputDir") + File.separator + CHROME_BROWSER_LOG_FILE);
+    return new Builder().usingAnyFreePort().withLogFile(logFile).withEnvironment(chromeEnvironment).build();
   }
 
   /**

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -72,6 +72,16 @@ public class ChromeDriverService extends DriverService {
   public final static String CHROME_DRIVER_LOG_FILE = "chromedriver.log";
 
   /**
+   * Environment variable to set default for chrome debug logs.
+   */
+  public final static String CHROME_LOG_FILE = "CHROME_LOG_FILE";
+
+  /**
+   * File that will hold the browser and extension logs from a Chrome session.
+   */
+  public final static String CHROME_BROWSER_LOG_FILE = "chrome.log";
+
+  /**
    *
    * @param executable The chromedriver executable.
    * @param port Which port to start the chromedriver on.
@@ -111,7 +121,9 @@ public class ChromeDriverService extends DriverService {
     Map<String, String> caps = (HashMap<String, String>) appdynamicsCapabilities;
     String logFilePath = caps.get("outputDir") + File.separator + CHROME_DRIVER_LOG_FILE;
     File logFile = new File(logFilePath);
-    return new Builder().usingAnyFreePort().withLogFile(logFile).build();
+    Map<String, String> chromeEnvironments = new HashMap<>();
+    chromeEnvironments.put(CHROME_LOG_FILE, caps.get("outputDir") + File.separator + CHROME_BROWSER_LOG_FILE);
+    return new Builder().usingAnyFreePort().withLogFile(logFile).withEnvironment(chromeEnvironments).build();
   }
 
   /**

--- a/java/client/src/org/openqa/selenium/ie/InternetExplorerDriver.java
+++ b/java/client/src/org/openqa/selenium/ie/InternetExplorerDriver.java
@@ -31,6 +31,8 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.service.DriverCommandExecutor;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 public class InternetExplorerDriver extends RemoteWebDriver {
 
@@ -211,9 +213,15 @@ public class InternetExplorerDriver extends RemoteWebDriver {
       InternetExplorerDriverService.Builder builder = new InternetExplorerDriverService.Builder();
       builder.usingPort(port);
 
+      Object appdynamicsCapabilities = caps.getCapability("appdynamicsCapability");
+      Map<String, String> appdCaps = (HashMap<String, String>) appdynamicsCapabilities;
+
       if (caps != null) {
         if (caps.getCapability(LOG_FILE) != null) {
           String value = (String) caps.getCapability(LOG_FILE);
+          if (appdCaps.containsKey("outputDir")) {
+            value = appdCaps.get("outputDir") + File.separator + value;
+          }
           if (value != null) {
             builder.withLogFile(new File(value));
           }


### PR DESCRIPTION
Changes done:
- Provided and used a new createDefaultServiceWithCustomOptions()
  factory method to create ChromeDriverService.
- This new method accepts capabilities as parameter and sets the
  default location of the logfile as the outputDir as provided in the
appdynamicsCapabilities.

Testing done:
- Tested locally with the standalone jar.
- Tested with the agent as well. chromedriver.log is captured for
  Chrome.