### PR TITLE
SYNTH-4005 SYNTH-4006 Capture logs from chromedriver, chrome browser console and extension

### DIFF
--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriver.java
@@ -144,7 +144,7 @@ public class ChromeDriver extends RemoteWebDriver
    */
   @Deprecated
   public ChromeDriver(Capabilities capabilities) {
-    this(ChromeDriverService.createDefaultService(), capabilities);
+    this(ChromeDriverService.createDefaultServiceWithLogging(capabilities), capabilities);
   }
 
   /**

--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.logging.Logger;
 
 /**
@@ -122,10 +121,10 @@ public class ChromeDriverService extends DriverService {
    *
    * @return A new ChromeDriverService using the default configuration and custom options.
    */
-  public static ChromeDriverService createDefaultService(Capabilities capabilities) {
+  public static ChromeDriverService createDefaultServiceWithLogging(Capabilities capabilities) {
     logger.addHandler(LoggingHandler.getInstance());
     Object appdynamicsCapabilities = capabilities.getCapability("appdynamicsCapability");
-    Map<String, String> caps = (TreeMap<String, String>) appdynamicsCapabilities;
+    Map<String, String> caps = (HashMap<String, String>) appdynamicsCapabilities;
     if (caps == null ||
         !caps.containsKey("captureLogs") ||
         caps.get("captureLogs") == null ||


### PR DESCRIPTION
If the appdynamicsCapabilities are set, selenium will look for a flag
"captureLogs". If this is set to true, two additional log files can be
seen in the measurement directory at the end of measurement -
chrome.log and chromedriver.log.

Testing notes:
- Ran @sanity for Chrome.