### PR TITLE
SYNTH-4156 Fix NPE during QUIT

### DIFF
--- a/java/server/src/org/openqa/selenium/remote/server/DriverServlet.java
+++ b/java/server/src/org/openqa/selenium/remote/server/DriverServlet.java
@@ -295,11 +295,18 @@ public class DriverServlet extends HttpServlet {
             "message", e.getMessage() == null ? "" : e.getMessage(),
             "stacktrace", Throwables.getStackTraceAsString(e),
             "stackTrace", Stream.of(e.getStackTrace())
-                .map(element -> ImmutableMap.of(
-                    "fileName", element.getFileName(),
-                    "className", element.getClassName(),
-                    "methodName", element.getMethodName(),
-                    "lineNumber", element.getLineNumber()))
+                .map(element -> {
+                  String fileName = element.getFileName();
+                  String className = element.getClassName();
+                  String methodName = element.getMethodName();
+                  int lineNumber = element.getLineNumber();
+                  return ImmutableMap.of(
+                      "fileName", fileName == null ? "UNKNOWN" : fileName,
+                      "className", className == null ? "UNKNOWN" : className,
+                      "methodName", methodName == null ? "UNKNOWN" : methodName,
+                      "lineNumber", lineNumber
+                  );
+                })
                 .collect(ImmutableList.toImmutableList())));
 
     byte[] bytes = new Json().toJson(value).getBytes(UTF_8);


### PR DESCRIPTION
Occasionally `driver.quit` encounters an error but the logic that
constructs the error message in turn encounters an NPE and as a result
we are unable to know what exactly went wrong. This commit fixes the bug
in the error message construction and hopefully help us identify the
underlying issue.

Testing notes:
- Ran @sanity on Chrome with these changes.