### PR TITLE
SYNTH-5956 Added "chromedriverExecutablePath" custom appD capability …

### DIFF
--- a/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
+++ b/java/client/src/org/openqa/selenium/chrome/ChromeDriverService.java
@@ -128,14 +128,16 @@ public class ChromeDriverService extends DriverService {
     if (caps == null ||
         !caps.containsKey("captureLogs") ||
         caps.get("captureLogs") == null ||
-        !caps.get("captureLogs").toLowerCase().equals("true")) {
-      logger.info("captureLogs was not set. Creating default service...");
+        !caps.get("captureLogs").toLowerCase().equals("true") ||
+        !caps.containsKey("chromedriverExecutablePath")) {
+      logger.info("appdynamicsCapabilities were not set. Creating default service...");
       return new Builder().usingAnyFreePort().build();
     }
     String logFilePath = caps.get("outputDir") + File.separator + CHROME_DRIVER_LOG_FILE;
     File logFile = new File(logFilePath);
     Map<String, String> chromeEnvironment = new HashMap<>();
     chromeEnvironment.put(CHROME_LOG_FILE, caps.get("outputDir") + File.separator + CHROME_BROWSER_LOG_FILE);
+    System.setProperty(CHROME_DRIVER_EXE_PROPERTY, caps.get("chromedriverExecutablePath"));
     logger.info("Creating ChromeDriverService with custom options...");
     return new Builder().usingAnyFreePort().withLogFile(logFile).withEnvironment(chromeEnvironment).build();
   }


### PR DESCRIPTION
RWDServer looks for a system property "webdriver.chrome.driver" to be set to find the chromedriver executable to run a Selenium test. If this property is not defined, it will try to find one on its own.

With the multiple versions of Chrome, we are required to deterministically pass the chromedriver executable so that we always pick the correct version. 

We do this by passing a custom capability while instantiating chromedriver service. If this capability is set, we internally set the "webdriver.chrome.driver" system property.